### PR TITLE
Fix URL matches bug

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ const notemuChromeext = {
 
 document.body.addEventListener('transitionend', () => {
   const path = location.pathname;
+  // "https://note.mu/<Username>/n/<Note ID>" or "https://<Domain>/n/<Note ID>"
   if (/^\/[\w\-]+\/n\/\w+$/.test(path) || /^\/n\/\w+$/.test(path))
     notemuChromeext.changeBackground();
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,8 +10,7 @@
   "content_scripts": [
     {
       "matches": [
-        "https://note.mu/*/n/*",
-        "https://*/n/*"
+        "https://*/*"
       ],
       "css": [
         "main.css"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_ext_name__",
   "description": "__MSG_ext_description__",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "icons": {
     "128": "icon_128.png"
   },


### PR DESCRIPTION
マッチパターンを任意の URL に変更。

note.mu は SPA のため、記事ページ以外からアクセスすると、記事ページへ遷移しても拡張機能が動作しないようになっていた。