### PR TITLE
Fix no element found bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,26 @@ note.mu の記事ページの背景を目に優しい色に変更する Chrome �
 
 ## Installation
 
-[Chrome ウェブストア](https://chrome.google.com/webstore/detail/background-color-enhancer/lmfhfgllepkjlgilfimmibkkphaafgnk)からインストールできます。
+You can install the extension from the [Chrome Web Store](https://chrome.google.com/webstore/detail/background-color-enhancer/lmfhfgllepkjlgilfimmibkkphaafgnk).
 
-## Reporting bugs and requesting enhancements
+## Contributing
 
-不具合報告または機能改善のリクエストは [issue](https://github.com/k-miyata/notemu-chromeextension/issues/new) からお願いいたします。
+If you encounter any bugs or have any questions, please [create a new issue](https://github.com/k-miyata/notemu-chromeextension/issues/new).
 
-## Development
+Also, I welcome pull requests to propose your ideas! Please refer to following development process:
 
 1. Clone this repository.
 2. Write code.
 3. Test your changes on Chrome. You can load `src` directory from the Extensions page in developer mode.
 4. Change `version` in `manifest.json`.
-5. Execute `build.sh` to make `package.zip` in `dist` directory.
-6. Upload the package to the Chrome Web Store.
+5. Send a pull request.
+
+If this changes are approved, @k-miyata, the repository owner, publish the update on the Chrome Web Store:
+
+6. Merge the pull request into `master`.
+7. Execute `build.sh` to make `package.zip` in `dist` directory.
+8. Upload the package to the Chrome Web Store.
 
 ## License
 
-The source code is released under the MIT license.
+This software is released under the MIT license.

--- a/src/main.js
+++ b/src/main.js
@@ -1,16 +1,17 @@
-const notemuChromeext = {
-  changeBackground() {
-    document
-      .querySelector('html[ng-app=noteApp] main:not([hidden])')
-      .classList.add('notemu-chromeext', 'enhanced-background');
-  }
+function changeBackground() {
+  document
+    .querySelector('html[ng-app=noteApp] main:not([hidden])')
+    .classList.add('notemu-chromeext', 'enhanced-background');
+}
+
+function isArticlePage() {
+  const path = location.pathname;
+  // "https://note.mu/<Username>/n/<Note ID>" or "https://<Domain>/n/<Note ID>"
+  return /^\/[\w\-]+\/n\/\w+$/.test(path) || /^\/n\/\w+$/.test(path);
 }
 
 document.body.addEventListener('transitionend', () => {
-  const path = location.pathname;
-  // "https://note.mu/<Username>/n/<Note ID>" or "https://<Domain>/n/<Note ID>"
-  if (/^\/[\w\-]+\/n\/\w+$/.test(path) || /^\/n\/\w+$/.test(path))
-    notemuChromeext.changeBackground();
+  if (isArticlePage()) changeBackground();
 });
 
-notemuChromeext.changeBackground();
+if (isArticlePage()) changeBackground();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_ext_name__",
   "description": "__MSG_ext_description__",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "icons": {
     "128": "icon_128.png"
   },


### PR DESCRIPTION
記事ページ以外や、そもそも note.mu ではないページで `notemuChromeext.changeBackground()` を実行してしまい、要素が見つからないとコンソールにエラーが表示されていた不具合の修正。

note.mu の記事ページ以外では関数を実行しないようにした。

また、Chrome 拡張機能のコードはグローバルを汚染しないため、関数を格納していたオブジェクト `notemuChromeext` を削除した。