### PR TITLE
Change query selector and path pattern

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ function changeBackground() {
 function isArticlePage() {
   const path = location.pathname;
   // "https://note.mu/<Username>/n/<Note ID>" or "https://<Domain>/n/<Note ID>"
-  return /^\/[\w\-]+\/n\/\w+$/.test(path) || /^\/n\/\w+$/.test(path);
+  return /^\/[\w\-]+\/n\/n[a-z0-9]{12}$/.test(path) || /^\/n\/n[a-z0-9]{12}$/.test(path);
 }
 
 document.body.addEventListener('transitionend', () => {

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 function changeBackground() {
   document
-    .querySelector('body.ns-note main:not([hidden])')
+    .querySelector('main.p-article:not([hidden])')
     .classList.add('notemu-chromeext', 'enhanced-background');
 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_ext_name__",
   "description": "__MSG_ext_description__",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "icons": {
     "128": "icon_128.png"
   },


### PR DESCRIPTION
再度 note の仕様変更により背景色が変更されなくなったため、背景色が変更されるよう修正。

ベースとなる要素に特徴的な class や属性がなくなったため、パスのパターンマッチングをより厳密なものに変更した（記事 ID が `n` から始まりランダムな英小文字・数字 12 文字）。