### PR TITLE
Migrate to Manifest V3

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "__MSG_ext_name__",
   "description": "__MSG_ext_description__",
   "version": "1.0.4",


### PR DESCRIPTION
[Migrating to Manifest V3](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/)を参考に、マニフェストをバージョン3にアップグレード。影響を受ける変更はなく、`manifest_version`を変更するだけで済んだ。