### PR TITLE
Change to use custom properties

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -1,3 +1,5 @@
-.notemu-chromeext.enhanced-background {
-  background-color: hsl(180, 2%, 92%)
+:root.chrome-extension-note-friendly {
+  --color-mercuryGray: hsl(0deg 0% 86%);
+  --color-concreteGray: hsl(0deg 0% 90%);
+  --color-white: hsl(166deg 2% 92%);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,17 +1,30 @@
-function changeBackground() {
-  document
-    .querySelector('main.p-article:not([hidden])')
-    .classList.add('notemu-chromeext', 'enhanced-background');
+/**
+ * Returns whether the user is on one of the pages on Note.
+ */
+function isNoteDomain() {
+  return document.location.hostname === "note.com";
 }
 
-function isArticlePage() {
-  const path = location.pathname;
-  // "https://note.mu/<Username>/n/<Note ID>" or "https://<Domain>/n/<Note ID>"
-  return /^\/[\w\-]+\/n\/n[a-z0-9]{12}$/.test(path) || /^\/n\/n[a-z0-9]{12}$/.test(path);
+/**
+ * Returns whether the user is on one of the article pages on Note connected to
+ * a custom domain. For these pages, applies the style only to the article pages
+ * that can be exactly determined to be on Note.
+ */
+function isArticlePageOnCustomDomain() {
+  return /^\/n\/n[a-z0-9]{12}$/.test(document.location.pathname);
 }
 
-document.body.addEventListener('transitionend', () => {
-  if (isArticlePage()) changeBackground();
-});
+/**
+ * Adds the class to `<html>` to apply the styles.
+ */
+function applyStyles() {
+  document.documentElement.classList.add("chrome-extension-note-friendly");
+}
 
-if (isArticlePage()) changeBackground();
+// This content script is injected after the DOM is complete, so you can access
+// the DOM without listening to the `DOMContentLoaded` event. See the
+// documentation for details on when content scripts are injected:
+// https://developer.chrome.com/docs/extensions/mv3/content_scripts/#run_time.
+if (isNoteDomain() || isArticlePageOnCustomDomain()) {
+  applyStyles();
+}

--- a/src/main.js
+++ b/src/main.js
@@ -18,13 +18,16 @@ function isArticlePageOnCustomDomain() {
  * Adds the class to `<html>` to apply the styles.
  */
 function applyStyles() {
-  document.documentElement.classList.add("chrome-extension-note-friendly");
+  if (isNoteDomain() || isArticlePageOnCustomDomain()) {
+    document.documentElement.classList.add("chrome-extension-note-friendly");
+  }
 }
 
 // This content script is injected after the DOM is complete, so you can access
 // the DOM without listening to the `DOMContentLoaded` event. See the
 // documentation for details on when content scripts are injected:
 // https://developer.chrome.com/docs/extensions/mv3/content_scripts/#run_time.
-if (isNoteDomain() || isArticlePageOnCustomDomain()) {
-  applyStyles();
-}
+applyStyles();
+
+// Applies the style when the user moves from an unscoped page to a scoped page.
+document.addEventListener("transitionend", applyStyles);


### PR DESCRIPTION
カスタムプロパティを上書きすることで色を変更するようにする。noteの配色を保ったまま変更することができ、さらに記事ページ以外の背景色も変更することができる。ただし、カスタムプロパティの名前が変更されると適用されなくなるというリスクはある。