### PR TITLE
Bump version to 2.0

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extension_name__",
   "description": "__MSG_extension_description__",
-  "version": "1.0.4",
+  "version": "2.0",
   "icons": {
     "128": "icon_128.png"
   },


### PR DESCRIPTION
ライブラリではないため、セマンティックバージョニングから2桁のバージョン番号に変更。1桁目の変更は機能の追加や改良、2桁目の変更は不具合修正を表す。

今回は、https://github.com/k-miyata/note-friendly/pull/8 によって記事ページ以外も背景色を変更するようにしたり、https://github.com/k-miyata/note-friendly/pull/9 によって拡張子の名前やアイコンを改良したりするため、1桁目を上げて2.0とする。