### PR TITLE
Fix icon color in dark mode

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -21,7 +21,7 @@
     --color-surface-successSubdued: hsl(172deg 6% 16%);
     --color-text-primary: hsl(0deg 0% 98%);
     --color-text-secondary: hsl(230deg 26% 92% / 0.66);
-    --color-text-clickable: hsl(230deg 26% 92% / 0.50);
+    --color-text-clickable-icon: hsl(230deg 26% 92% / 0.50);
     --color-text-success: hsl(172deg 68% 50%);
     --color-text-success-reaction: hsl(172deg 68% 74%);
     --color-text-caution: hsl(38deg 100% 67%);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extension_name__",
   "description": "__MSG_extension_description__",
-  "version": "3.1",
+  "version": "3.2",
   "icons": {
     "128": "icon_128.png"
   },


### PR DESCRIPTION
## 概要

ダークモードにおいてグレーのアイコンが黒くて見えない問題を修正。

アイコンに適用されているカスタムプロパティの名前 `--color-text-clickable` が `--color-text-clickable-icon` に変更された模様。

## イメージ

### 変更前

<img width="1396" alt="スクリーンショット 2024-04-20 22 34 20" src="https://github.com/k-miyata/note-friendly/assets/18201546/1e454b1e-70f6-4078-ae49-6a71ee15fee7">

### 変更後

<img width="1396" alt="スクリーンショット 2024-04-20 22 34 04" src="https://github.com/k-miyata/note-friendly/assets/18201546/28a8e702-2252-462f-ac1a-e884b85a867c">