### PR TITLE
Add color scheme preference

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -6,5 +6,21 @@
   "extension_description": {
     "message": "Changes the background of Note to the more eye-friendly colors.",
     "description": "The description of this extention."
+  },
+  "color_scheme_preference_caption": {
+    "message": "Color Scheme",
+    "description": "The caption for the preference that changes the color scheme."
+  },
+  "color_scheme_preference_auto_option_label": {
+    "message": "Auto",
+    "description": "The label for the option that changes the color scheme based on the system preferences."
+  },
+  "color_scheme_preference_light_option_label": {
+    "message": "Light",
+    "description": "The label for the option that changes the color scheme to light."
+  },
+  "color_scheme_preference_dark_option_label": {
+    "message": "Dark",
+    "description": "The label for the option that changes the color scheme to dark."
   }
 }

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -6,5 +6,21 @@
   "extension_description": {
     "message": "noteの背景を目に優しい色に変更します。",
     "description": "この拡張機能の説明。"
+  },
+  "color_scheme_preference_caption": {
+    "message": "配色",
+    "description": "カラースキームを変更する設定のキャプション。"
+  },
+  "color_scheme_preference_auto_option_label": {
+    "message": "自動",
+    "description": "カラースキームをシステム設定に合わせるオプションのラベル。"
+  },
+  "color_scheme_preference_light_option_label": {
+    "message": "ライト",
+    "description": "カラースキームをライトモードにするオプションのラベル。"
+  },
+  "color_scheme_preference_dark_option_label": {
+    "message": "ダーク",
+    "description": "カラースキームをダークモードにするオプションのラベル。"
   }
 }

--- a/src/main.css
+++ b/src/main.css
@@ -3,36 +3,34 @@
   --color-background-primary: hsl(166deg 2% 92%);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root.chrome-extension-note-friendly {
-    --color-whiteAlpha-700: hsl(0deg 0% 0% / 0.82);
-    --color-blackAlpha-900: hsl(0deg 0% 100%);
-    --color-blackAlpha-600: hsl(0deg 0% 100% / 0.66);
-    --color-grayAlpha-600: hsl(230deg 26% 92% / 0.66);
-    --color-grayAlpha-300: hsl(230deg 26% 92% / 0.32);
-    --color-grayAlpha-200: hsl(230deg 26% 92% / 0.22);
-    --color-gray-900: hsl(230deg 26% 92%);
-    --color-note-accent: hsl(172deg 68% 50%);
-    --color-note-accent-reaction: hsl(172deg 68% 74%);
-    --color-custom-accent: hsl(172deg 68% 50%);
-    --color-custom-accent-reaction: hsl(172deg 68% 74%);
-    --color-surface-primary: hsl(172deg 68% 50%);
-    --color-surface-normal: hsl(172deg 1% 16%);
-    --color-surface-successSubdued: hsl(172deg 6% 16%);
-    --color-text-primary: hsl(0deg 0% 98%);
-    --color-text-secondary: hsl(230deg 26% 92% / 0.66);
-    --color-text-clickable-icon: hsl(230deg 26% 92% / 0.50);
-    --color-text-success: hsl(172deg 68% 50%);
-    --color-text-success-reaction: hsl(172deg 68% 74%);
-    --color-text-caution: hsl(38deg 100% 67%);
-    --color-text-like: hsl(340deg 100% 68%);
-    --color-text-invert: hsl(0deg 0% 0%);
-    --color-text-placeholder: hsl(230deg 10% 72%);
-    --color-border-default: hsl(230deg 26% 92% / 0.14);
-    --color-border-weak: hsl(230deg 26% 92% / 0.03);
-    --color-border-strong: hsl(230deg 26% 92% / 0.22);
-    --color-background-primary: hsl(172deg 1% 16%);
-    --color-background-default: hsl(172deg 1% 16%);
-    --color-background-secondary: hsl(172deg 1% 20%);
-  }
+:root.chrome-extension-note-friendly[data-chrome-extension-note-friendly-color-scheme=dark] {
+  --color-whiteAlpha-700: hsl(0deg 0% 0% / 0.82);
+  --color-blackAlpha-900: hsl(0deg 0% 100%);
+  --color-blackAlpha-600: hsl(0deg 0% 100% / 0.66);
+  --color-grayAlpha-600: hsl(230deg 26% 92% / 0.66);
+  --color-grayAlpha-300: hsl(230deg 26% 92% / 0.32);
+  --color-grayAlpha-200: hsl(230deg 26% 92% / 0.22);
+  --color-gray-900: hsl(230deg 26% 92%);
+  --color-note-accent: hsl(172deg 68% 50%);
+  --color-note-accent-reaction: hsl(172deg 68% 74%);
+  --color-custom-accent: hsl(172deg 68% 50%);
+  --color-custom-accent-reaction: hsl(172deg 68% 74%);
+  --color-surface-primary: hsl(172deg 68% 50%);
+  --color-surface-normal: hsl(172deg 1% 16%);
+  --color-surface-successSubdued: hsl(172deg 6% 16%);
+  --color-text-primary: hsl(0deg 0% 98%);
+  --color-text-secondary: hsl(230deg 26% 92% / 0.66);
+  --color-text-clickable-icon: hsl(230deg 26% 92% / 0.50);
+  --color-text-success: hsl(172deg 68% 50%);
+  --color-text-success-reaction: hsl(172deg 68% 74%);
+  --color-text-caution: hsl(38deg 100% 67%);
+  --color-text-like: hsl(340deg 100% 68%);
+  --color-text-invert: hsl(0deg 0% 0%);
+  --color-text-placeholder: hsl(230deg 10% 72%);
+  --color-border-default: hsl(230deg 26% 92% / 0.14);
+  --color-border-weak: hsl(230deg 26% 92% / 0.03);
+  --color-border-strong: hsl(230deg 26% 92% / 0.22);
+  --color-background-primary: hsl(172deg 1% 16%);
+  --color-background-default: hsl(172deg 1% 16%);
+  --color-background-secondary: hsl(172deg 1% 20%);
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -7,6 +7,12 @@
     "128": "icon_128.png"
   },
   "default_locale": "en",
+  "permissions": [
+    "storage"
+  ],
+  "action": {
+    "default_popup": "popup.html"
+  },
   "content_scripts": [
     {
       "matches": [

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extension_name__",
   "description": "__MSG_extension_description__",
-  "version": "3.2",
+  "version": "4.0",
   "icons": {
     "128": "icon_128.png"
   },

--- a/src/popup.css
+++ b/src/popup.css
@@ -1,0 +1,18 @@
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  width: 8rem;
+}
+
+.label {
+  display: inline-flex;
+  padding: 0.25em;
+  gap: 0.5em;
+  align-items: center;
+}
+
+.radio {
+  margin: 0;
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title data-locale="extension_name">Note Friendly</title>
+    <script defer src="popup.js"></script>
+  </head>
+  <body>
+    <fieldset>
+      <legend data-locale="color_scheme_preference_caption">Color Scheme</legend>
+      <div>
+        <label>
+          <input type="radio" name="colorScheme" value="auto" checked>
+          <span data-locale="color_scheme_preference_auto_option_label">Auto</span>
+        </label>
+      </div>
+      <div>
+        <label>
+          <input type="radio" name="colorScheme" value="light">
+          <span data-locale="color_scheme_preference_light_option_label">Light</span>
+        </label>
+      </div>
+      <div>
+        <label>
+          <input type="radio" name="colorScheme" value="dark">
+          <span data-locale="color_scheme_preference_dark_option_label">Dark</span>
+        </label>
+      </div>
+    </fieldset>
+  </body>
+</html>

--- a/src/popup.html
+++ b/src/popup.html
@@ -4,25 +4,26 @@
     <meta charset="utf-8">
     <title data-locale="extension_name">Note Friendly</title>
     <script defer src="popup.js"></script>
+    <link rel="stylesheet" href="popup.css">
   </head>
   <body>
     <fieldset>
       <legend data-locale="color_scheme_preference_caption">Color Scheme</legend>
       <div>
-        <label>
-          <input type="radio" name="colorScheme" value="auto" checked>
+        <label class="label">
+          <input class="radio" type="radio" name="colorScheme" value="auto" checked>
           <span data-locale="color_scheme_preference_auto_option_label">Auto</span>
         </label>
       </div>
       <div>
-        <label>
-          <input type="radio" name="colorScheme" value="light">
+        <label class="label">
+          <input class="radio" type="radio" name="colorScheme" value="light">
           <span data-locale="color_scheme_preference_light_option_label">Light</span>
         </label>
       </div>
       <div>
-        <label>
-          <input type="radio" name="colorScheme" value="dark">
+        <label class="label">
+          <input class="radio" type="radio" name="colorScheme" value="dark">
           <span data-locale="color_scheme_preference_dark_option_label">Dark</span>
         </label>
       </div>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,0 +1,35 @@
+"use strict";
+
+function translate() {
+  document.querySelectorAll("[data-locale]").forEach((element) => {
+    element.textContent = chrome.i18n.getMessage(element.dataset.locale);
+  });
+}
+
+async function getCurrentPreferences() {
+  const results = await chrome.storage.local.get("colorScheme");
+  const { colorScheme } = results;
+  if (colorScheme) {
+    const radio = document.querySelector(`input[name=colorScheme][value='${colorScheme}']`);
+    if (radio) {
+      radio.checked = true;
+    }
+  }
+}
+
+async function setColorScheme(value) {
+  await chrome.storage.local.set({ colorScheme: value });
+  getCurrentPreferences();
+}
+
+function addEventListenersToControls() {
+  document.querySelectorAll("input[name=colorScheme]").forEach((radio) => {
+    radio.addEventListener("change", (event) => {
+      setColorScheme(event.currentTarget.value);
+    });
+  });
+}
+
+document.addEventListener("DOMContentLoaded", translate);
+document.addEventListener("DOMContentLoaded", getCurrentPreferences);
+document.addEventListener("DOMContentLoaded", addEventListenersToControls);


### PR DESCRIPTION
Closes #13

OSの外観モードに連動せず、常にライトモードまたはダークモードに固定できるようにする。

拡張機能のアイコンをクリックするとポップアップが表示され、そこで配色を変更できる。ここで選択した配色はブラウザに保存される（[`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage) APIを使用）。

- 自動：OSの外観モードに合わせる（デフォルト）
- ライト：OSの外観モードによらず常にライトグレーにする
- ダーク：OSの外観モードによらず常にダークにする

<img width="206" alt="スクリーンショット 2024-07-06 22 06 33" src="https://github.com/k-miyata/note-friendly/assets/18201546/dde7d4e2-530d-4566-9d44-b6eec19b2e05">