### PR TITLE
Fix text color in code blocks

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -33,4 +33,8 @@
   --color-background-primary: hsl(172deg 1% 16%);
   --color-background-default: hsl(172deg 1% 16%);
   --color-background-secondary: hsl(172deg 1% 20%);
+
+  .code-block-container {
+    --color-text-invert: initial;
+  }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extension_name__",
   "description": "__MSG_extension_description__",
-  "version": "4.0",
+  "version": "4.1",
   "icons": {
     "128": "icon_128.png"
   },


### PR DESCRIPTION
ダークモードのとき、コードブロックの文字が背景と同じ色になってしまい読めない不具合を修正。背景はモード問わず黒色のため、文字もモード問わず白色（初期値）にする。

ハイライトされる部分は問題ないため、変更なし。